### PR TITLE
update: returns an error if also rowCount is zero

### DIFF
--- a/src/v1/components/references/referencesController.js
+++ b/src/v1/components/references/referencesController.js
@@ -146,7 +146,7 @@ class References {
 
       const referencesResult = await Postgres.query(referencesRequest, [id]);
 
-      if (!referencesResult) {
+      if (!referencesResult || referencesResult.rowCount === 0) {
         throw new ErrorReferenceNotFound();
       }
 
@@ -178,7 +178,7 @@ class References {
 
       const referencesResult = await Postgres.query(referencesRequest, [id]);
 
-      if (!referencesResult) {
+      if (!referencesResult || referencesResult.rowCount === 0) {
         throw new ErrorReferenceNotFound();
       }
 
@@ -211,7 +211,8 @@ class References {
       `;
 
       const referencesResult = await Postgres.query(referencesRequest, [userId]);
-      if (!referencesResult) {
+
+      if (!referencesResult || referencesResult.rowCount === 0) {
         throw new ErrorReferenceNotFound();
       }
 
@@ -255,7 +256,7 @@ class References {
       `;
       const referenceResult = await Postgres.query(referenceRequest, [id]);
 
-      if (!referenceResult) {
+      if (!referenceResult || referenceResult.rowCount === 0) {
         throw new ErrorReferenceNotFound("The theme cannot be found", 401);
       }
 


### PR DESCRIPTION
The queries have been modified to return an error if the number of columns in the database result is empty and to process the information on the front end