### PR TITLE
fix: search must not return an error

### DIFF
--- a/src/v1/components/search/searchController.js
+++ b/src/v1/components/search/searchController.js
@@ -50,9 +50,6 @@ class Search {
         `;
   
         const referenceResult = await Postgres.query(referencesRequest);
-        if (referenceResult.rowCount === 0) {
-          return next(new ErrorSearchNoResult())
-        }
 
         response.status(200).json({
           search : referenceResult.rows


### PR DESCRIPTION
The error returned in the case where no reference was found has been removed.
Finally, the reference is created.